### PR TITLE
Allow to disable diffing by passing -diff-cmd -

### DIFF
--- a/evaluator/ppx_expect_evaluator.ml
+++ b/evaluator/ppx_expect_evaluator.ml
@@ -92,23 +92,34 @@ let process_group ~use_color ~in_place ~diff_command { filename; file_contents; 
     remove dot_corrected;
     Success
   | _ ->
-    (* We need a temporary file for corrections to allow [Print_diff] to work when
-       multiple inline_tests_runner are run simultaneously. Otherwise one copy may remove
-       the corrected file before the other can print the diff. *)
-    let tmp_corrected =
-      Caml.Filename.temp_file (Caml.Filename.basename filename) ".tmp_corrected"
-        ~temp_dir:(Caml.Filename.dirname filename)
+    let no_diff =
+      match diff_command with
+      | Some "-" -> true
+      | None | Some _ -> false
+    in
+    let dest =
+      if in_place then
+        filename
+      else if no_diff then
+        dot_corrected
+      else
+        (* We need a temporary file for corrections to allow [Print_diff] to work when
+           multiple inline_tests_runner are run simultaneously. Otherwise one copy may
+           remove the corrected file before the other can print the diff. *)
+        Caml.Filename.temp_file (Caml.Filename.basename filename) ".tmp_corrected"
+          ~temp_dir:(Caml.Filename.dirname filename)
     in
     Matcher.write_corrected bad_outcomes
-      ~file:(if in_place then filename else tmp_corrected)
+      ~file:dest
       ~file_contents ~mode:Inline_expect_test;
     if in_place then begin
       remove dot_corrected;
-      remove tmp_corrected;
       Success
-    end else begin
-      Print_diff.print ~file1:filename ~file2:tmp_corrected ~use_color ?diff_command ();
-      Caml.Sys.rename tmp_corrected dot_corrected;
+    end else if no_diff then
+      Success
+    else begin
+      Print_diff.print ~file1:filename ~file2:dest ~use_color ?diff_command ();
+      Caml.Sys.rename dest dot_corrected;
       Failure
     end
 ;;


### PR DESCRIPTION
Similar to https://github.com/janestreet/ppx_driver/pull/17, to allow expect tests to work with jbuilder: when `-diff-cmd -` is passed to the test runner, the ppx_expect test runtime will only write the `.corrected` file without printing a diff or exiting with a non-zero exit code.