### PR TITLE
README.org: Fix source code quote

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,7 +39,7 @@ let%expect_test "addition" =
 : +++foo.ml.corrected
 : File "foo.ml", line 5, characters 0-1:
 :   open Core
-:
+: 
 :   let%expect_test "addition" =
 :     printf "%d" (1 + 2);
 : -|  [%expect {| 4 |}]

--- a/README.org
+++ b/README.org
@@ -35,15 +35,17 @@ let%expect_test "addition" =
 
 =inline_tests_runner= will also output the diff:
 
-: ---foo.ml
-: +++foo.ml.corrected
-: File "foo.ml", line 5, characters 0-1:
-:   open Core
-: 
-:   let%expect_test "addition" =
-:     printf "%d" (1 + 2);
-: -|  [%expect {| 4 |}]
-: +|  [%expect {| 3 |}]
+#+begin_src
+---foo.ml
++++foo.ml.corrected
+File "foo.ml", line 5, characters 0-1:
+  open Core
+
+  let%expect_test "addition" =
+    printf "%d" (1 + 2);
+-|  [%expect {| 4 |}]
++|  [%expect {| 3 |}]
+#+end_src
 
 Diffs will be shown in color if the =-use-color= flag is passed to the test runner executable.
 


### PR DESCRIPTION
Apparently a space after the colon is necessary. I don't use org-mode, and only tested against the rendering on Github. Sorry if this is just Github's rendering being broken.