### PR TITLE
Windows: Add CR to ignore list for multi-line check

### DIFF
--- a/expect_payload/ppx_expect_payload.ml
+++ b/expect_payload/ppx_expect_payload.ml
@@ -59,7 +59,7 @@ let make ~kind payload ~(extension_id_loc:Location.t) =
     let rec first_line i =
       match get i with
       | None              -> ()
-      | Some (' ' | '\t') -> first_line (i + 1)
+      | Some (' ' | '\t' | '\r') -> first_line (i + 1)
       | Some '\n'         -> ()
       | Some _            -> first_line_has_stuff (i + 1)
     and first_line_has_stuff i =
@@ -70,7 +70,7 @@ let make ~kind payload ~(extension_id_loc:Location.t) =
     and rest_must_be_empty i =
       match get i with
       | None -> ()
-      | Some (' ' | '\t' | '\n') ->
+      | Some (' ' | '\t' | '\r' | '\n') ->
         rest_must_be_empty (i + 1)
       | Some _  ->
         Location.raise_errorf ~loc:body_loc


### PR DESCRIPTION
__Issue:__ When using `ppx_expect` with Windows-style newlines (`CRLF` vs `LF`), the multi-line expectation fails with:
```
         ppx lib/Util.pp.ml (exit 1)
(cd _build/default && .ppx/ppx_expect+ppx_inline_test+ppxlib/ppx.exe --cookie "library-name=\"lib\"" -o lib/Util.pp.ml --impl lib/Util.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
File "lib/Util.ml", line 7, characters 13-26:
Error: Multi-line expectations must start with an empty line
```

__Defect:__ The current code considers the `CR` (`/r`) a character, and fails the check.

__Fix:__ Ignore the `/r` as we do for other whitespace.

We hit this in our Windows build of esy: esy/esy#499

Signed-off-by: Bryan Phelps <bryphe@outlook.com>
