### PR TITLE
Update how to use v0.14 with lwt 5.4 in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -200,13 +200,14 @@ module Lwt_io_flush = struct
 end
 
 module Expect_test_config :
-  Expect_test_config.S
+  Expect_test_config_types.S
     with module IO_run = Lwt_io_run
      and module IO_flush = Lwt_io_flush = struct
   module IO_run = Lwt_io_run
   module IO_flush = Lwt_io_flush
   let run x = Lwt_main.run (x ())
   let flushed () = Lwt_io.(buffered stdout = 0)
+  let flush () = Lwt_io.flush_all ()
   let upon_unreleasable_issue = `CR
 end
 #+end_src


### PR DESCRIPTION
The description about Lwt in the current README is deprecated: `Expect_test_config.S` is not defined but `Expect_test_config_types.S` requires a field `val flush : unit -> unit IO_flush.t`.