### PR TITLE
README: New usage example for LWT

### DIFF
--- a/README.org
+++ b/README.org
@@ -186,25 +186,20 @@ as the former.
 This is what you would need to write expect tests with Lwt:
 
 #+begin_src ocaml
-module Lwt_io_run = struct
+module Lwt_io = struct
   type 'a t = 'a Lwt.t
-end
 
-module Lwt_io_flush = struct
-  type 'a t = 'a Lwt.t
   let return x = Lwt.return x
   let bind x ~f = Lwt.bind x f
   let to_run x = x
 end
 
-module Expect_test_config :
-  Expect_test_config_types.S
-    with module IO_run = Lwt_io_run
-     and module IO_flush = Lwt_io_flush = struct
-  module IO_run = Lwt_io_run
-  module IO_flush = Lwt_io_flush
+module Expect_test_config : Expect_test_config_types.S with module IO = Lwt_io = struct
+  module IO = Lwt_io
+
   let run x = Lwt_main.run (x ())
   let upon_unreleasable_issue = `CR
+  let sanitize id = id
 end
 #+end_src
 


### PR DESCRIPTION
With ppx_expect v0.16 there was a change to Expect_test_config_types.S where IO_run and IO_flush were replaced with IO. This PR updates the usage example to reflect that.