### PR TITLE
fix(README): remove tags hiding end of the content

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -163,8 +163,6 @@ The formatting applied depends on the type of delimiter used in `str` (i.e. whet
 Here is an example containing several cases of output that are subject to distinct
 formatting rules and how they appear in `[%expect]` and `[%expect_exact]` blocks:
 
-<details>
-<summary>Expand examples</summary>
 <!-- $MDX file=./test/negative-tests/for-mdx/mdx_cases.ml.corrected.expected,part=matching -->
 ```ocaml
 let%expect_test "matching behavior --- no content" =
@@ -246,7 +244,6 @@ Over many a quaint and curious
     \  volume of forgotten lore "]
 ;;
 ```
-</details>
 
 Expect-test is by default permissive about this formatting, so that a
 `[%expect]` block that is correct modulo formatting is


### PR DESCRIPTION
I removed the `details` and `summary` HTML tags used to wrap `./test/negative-tests/for-mdx/mdx_cases.ml.corrected.expected`'s `part=matching` that were hiding the end of `README.mdx` and breaking the code block.

This is how `README.mdx` looks without this PR.
![image](https://github.com/janestreet/ppx_expect/assets/71153264/a8c53f0a-ea50-4821-a2a1-293af286b88b)
![image](https://github.com/janestreet/ppx_expect/assets/71153264/85ed9177-eb84-4089-bd27-a331eadbb0f1)

To see how it looks with this PR:
https://github.com/GitFenixZ/ppx_expect/tree/fix-readme-hidden-content

PS: I don't know much about MDX, so I'm not sure if this is even a "fix" or the best way to fix it. If you have a better solution, go for it!