### PR TITLE
Use dedicated runtime functions instead of relying on caml_ml_channels explicitly

### DIFF
--- a/ppx_expect.opam
+++ b/ppx_expect.opam
@@ -19,6 +19,10 @@ depends: [
   "ppxlib"          {>= "0.28.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
 synopsis: "Cram like framework for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/runtime/runtime.js
+++ b/runtime/runtime.js
@@ -4,30 +4,27 @@ var ppx_expect_runtime_saved_stdout
 var ppx_expect_runtime_saved_stderr
 
 //Provides: ppx_expect_runtime_before_test
-//Requires: caml_ml_channels
+//Requires: caml_ml_channel_redirect
 //Requires: ppx_expect_runtime_saved_stderr, ppx_expect_runtime_saved_stdout
 function ppx_expect_runtime_before_test (voutput, vstdout, vstderr){
-  ppx_expect_runtime_saved_stderr = caml_ml_channels[vstderr];
-  ppx_expect_runtime_saved_stdout = caml_ml_channels[vstdout];
-  var output = caml_ml_channels[voutput];
-  caml_ml_channels[vstdout] = output;
-  caml_ml_channels[vstderr] = output;
+  ppx_expect_runtime_saved_stderr = caml_ml_channel_redirect(vstderr, voutput);
+  ppx_expect_runtime_saved_stdout = caml_ml_channel_redirect(vstdout, voutput);
   return 0;
 }
 
 //Provides: ppx_expect_runtime_after_test
-//Requires: caml_ml_channels
+//Requires: caml_ml_channel_restore
 //Requires: ppx_expect_runtime_saved_stderr, ppx_expect_runtime_saved_stdout
 function ppx_expect_runtime_after_test (vstdout, vstderr){
-  caml_ml_channels[vstdout] = ppx_expect_runtime_saved_stdout;
-  caml_ml_channels[vstderr] = ppx_expect_runtime_saved_stderr;
+  caml_ml_channel_restore(vstdout,ppx_expect_runtime_saved_stdout);
+  caml_ml_channel_restore(vstderr,ppx_expect_runtime_saved_stderr);
   return 0;
 }
 
 //Provides: ppx_expect_runtime_out_channel_position
-//Requires: caml_ml_channels
+//Requires: caml_ml_channel_get
 function ppx_expect_runtime_out_channel_position(chan){
-  var info = caml_ml_channels[chan];
+  var info = caml_ml_channel_get(chan);
   return info.offset
 }
 


### PR DESCRIPTION
This goes with https://github.com/ocsigen/js_of_ocaml/pull/1601 and should allow fixing memory leak of ocaml channels.

We first need a new release of jsoo that include the new api. We can then merge this PR (and release ppx_expect) and finally merge https://github.com/ocsigen/js_of_ocaml/pull/1601 