### PR TITLE
Fix formatting in README

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -165,6 +165,7 @@ formatting rules and how they appear in `[%expect]` and `[%expect_exact]` blocks
 
 <details>
 <summary>Expand examples</summary>
+
 <!-- $MDX file=./test/negative-tests/for-mdx/mdx_cases.ml.corrected.expected,part=matching -->
 ```ocaml
 let%expect_test "matching behavior --- no content" =


### PR DESCRIPTION
I just added a newline.

Before this change the example code block in the "Matching behavior" section rendered incorrectly. This caused the `</details>` end tag to be misinterpreted as part of a codeblock, which then caused the incorrectly rendered codeblock and the rest of the document following to be collapsed under "Expand examples".