### PR TITLE
Fix regression for windows support in v0.17.0

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -5,7 +5,7 @@
  (name ppx_expect_runtime)
  (public_name ppx_expect.runtime)
  (libraries base stdio ppx_inline_test.runtime-lib make_corrected_file
-   expect_test_config)
+   expect_test_config expect_test_config_types ppx_expect_runtime_types)
  (js_of_ocaml
   (javascript_files runtime.js))
  (preprocess no_preprocessing))

--- a/runtime/expectation.mli
+++ b/runtime/expectation.mli
@@ -1,1 +1,0 @@
-include Expectation_intf.Expectation

--- a/runtime/output.ml
+++ b/runtime/output.ml
@@ -1,5 +1,5 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 module Type = struct
   type t =
@@ -35,27 +35,6 @@ module Test_result = struct
     | Pass, _ -> -1
     | _, Pass -> 1
     | Fail a, Fail b -> Reconciled.compare a b
-  ;;
-end
-
-module Payload = struct
-  type t =
-    { contents : string
-    ; tag : String_node_format.Delimiter.t
-    }
-
-  let default contents = { contents; tag = String_node_format.Delimiter.default }
-
-  let to_source_code_string { contents; tag } =
-    let escape_lines test_output =
-      test_output
-      |> String.split ~on:'\n'
-      |> List.map ~f:String.escaped
-      |> String.concat ~sep:"\n"
-    in
-    match tag with
-    | T (Tag tag) -> Printf.sprintf "{%s|%s|%s}" tag contents tag
-    | T Quote -> Printf.sprintf {|"%s"|} (escape_lines contents)
   ;;
 end
 

--- a/runtime/output.mli
+++ b/runtime/output.mli
@@ -1,12 +1,12 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 module Type : sig
   (** How the output expected at a node interacts with whitespace. *)
   type t =
     | Exact (** Matches the captured output exactly, including whitespace. *)
     | Pretty
-        (** Matches a version of the captured output that has been formatted according to
+    (** Matches a version of the captured output that has been formatted according to
         standard rules about indentation and other whitespace. *)
 end
 
@@ -42,22 +42,6 @@ module Test_result : sig
     | Fail of Reconciled.t
 
   val compare : t -> t -> int
-end
-
-module Payload : sig
-  (** Payloads given as arguments to expectation AST nodes. *)
-  type t =
-    { contents : string
-        (** The contents of the payload; the output expected at some node, as a raw [string]
-        exactly as they were parsed from the source file. *)
-    ; tag : String_node_format.Delimiter.t (** The delimiters used in the payload. *)
-    }
-
-  (** Add the default tags to a payload. *)
-  val default : string -> t
-
-  (** The source-code representation of a payload. *)
-  val to_source_code_string : t -> string
 end
 
 (** Returns [Pass] if [test_output] is considered to match [expected_output]; otherwise

--- a/runtime/ppx_expect_runtime.ml
+++ b/runtime/ppx_expect_runtime.ml
@@ -1,86 +1,5 @@
 open! Base
-
-(** This library provides the runtime representation of expect tests and much of the logic
-    for running them.
-
-    The [Test_block] module defines the runtime representation of the whole
-    [let%expect_test] block. It exports a [Make] functor that is used in generated code to
-    produce a module from the locally bound [Expect_test_config]. [run_suite] from the
-    resulting module takes in remaining information about the expect test, including
-    inline test configurations, information about the contained expectations, and a
-    callback containing the body of the test.
-
-    The [~expectations] argument to [run_suite] is an assoc list mapping unique ids to
-    [Test_node.t]s. A [Test_node.t] stores the representation of a single [[%expect]] test
-    AST node and collects the results of tests that reach this node.
-
-    In the body of the test, the [[%expect]] AST nodes are replaced by calls to
-    [run_test], with the appropriate id passed as an argument.
-
-    For an example, consider a file that contains just the simple [let%expect_test] below:
-
-    {[
-      let%expect_test _ =
-        print_string "Hello";
-        [%expect {| Hello |}];
-        print_string "world";
-        [%expect_exact {x|world|x}]
-      ;;
-    ]}
-
-    It will expand to code that looks something like this:
-
-    {[
-      (* This statement is added to the top of each rewritten file; it is used to make
-         sure tests are only run from the files in which they are declared. *)
-      let () =
-        Ppx_expect_runtime.Current_file.set
-          ~filename_rel_to_project_root:"foo/bar/test/test.ml"
-
-      (* Each test expands into something that looks approximately like this. Some of the
-         arguments to [Ppx_expect_test_block.run_suite] are elided for clarity. *)
-      let () =
-        (* Prepare to read test output using the settings from [Expect_test_config] *)
-        let module Ppx_expect_test_block =
-          Ppx_expect_runtime.Make_test_block(Expect_test_config) in
-        Ppx_expect_test_block.run_suite
-          (* The name of the file in which the test is defined. This lets the runtime
-             check that the filename set here at ppx-time matches the one that is set by
-             the block above at runtime. If the test were defined in a functor and that
-             functor invoked from another file, the filenames would not match. *)
-          ~filename_rel_to_project_root:"foo/bar/test/test.ml"
-          (* The ids that should be used when registering the trailing output test and the
-             uncaught exception tests. They are minted at ppx time because that is the
-             time that it is easiest to guarantee their uniqueness. *)
-          ~trailing_test_id:(Ppx_expect_runtime.Expectation_id.of_int 2)
-          ~exn_test_id:(Ppx_expect_runtime.Expectation_id.of_int 3)
-          (* An assoc list mapping ids to representations of expect nodes that appear in
-             this test. Later, when encountering expect nodes, information about them is
-             looked up in this table. *)
-          ~expectations:(([(Ppx_expect_runtime.Expectation_id.of_int 1,
-                            Ppx_expect_runtime.Test_node.Create.expect_exact
-                              { contents = "world"; tag = (Tag "x") }
-                              { start_bol = ...; start_pos = ...; end_pos = ... });
-                           (Ppx_expect_runtime.Expectation_id.of_int 0,
-                            Ppx_expect_runtime.Test_node.Create.expect
-                              { contents = " Hello "; tag = (Tag "") }
-                              { start_bol = ...; start_pos = ...; end_pos = ... })])
-                        )
-          (* The body of the let binding is passed as a callback. *)
-          (fun () ->
-             print_string "Hello";
-             (* Tests are run by passing in the id of the encountered test node. *)
-             Ppx_expect_test_block.run_test
-               ~test_id:(Ppx_expect_runtime.Expectation_id.of_int 0);
-             print_string "world";
-             Ppx_expect_test_block.run_test
-               ~test_id:(Ppx_expect_runtime.Expectation_id.of_int 1))
-
-      (* This statement is added to the end of each file so that the expect test runtime
-         knows the file is finished executing and a new one can be set as current. *)
-      let () = Ppx_expect_runtime.Current_file.unset ()
-    ]}
-*)
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 (* Register the reachability check and corrected file writing as an evaluator with
    [Ppx_inline_test_lib] *)
@@ -89,14 +8,14 @@ let () =
     Stdlib.Sys.chdir (Lazy.force Current_file.initial_dir);
     Test_node.Global_results_table.process_each_file
       ~f:(fun ~filename ~test_nodes ~postprocess ->
-      Write_corrected_file.f
-        test_nodes
-        ~use_color:(Ppx_inline_test_lib.use_color ())
-        ~in_place:(Ppx_inline_test_lib.in_place ())
-        ~diff_command:(Ppx_inline_test_lib.diff_command ())
-        ~diff_path_prefix:(Ppx_inline_test_lib.diff_path_prefix ())
-        ~with_:postprocess
-        ~filename)
+        Write_corrected_file.f
+          test_nodes
+          ~use_color:(Ppx_inline_test_lib.use_color ())
+          ~in_place:(Ppx_inline_test_lib.in_place ())
+          ~diff_command:(Ppx_inline_test_lib.diff_command ())
+          ~diff_path_prefix:(Ppx_inline_test_lib.diff_path_prefix ())
+          ~with_:postprocess
+          ~filename)
     |> Ppx_inline_test_lib.Test_result.combine_all)
 ;;
 
@@ -105,26 +24,14 @@ let () = Stdlib.at_exit Test_block.at_exit
 
 (* Exported definitions *)
 
-module Expect_node_formatting = Types.Expect_node_formatting
-module Compact_loc = Types.Compact_loc
-module Expectation_id = Types.Expectation_id
-module Delimiter = Types.String_node_format.Delimiter
-module Payload = Output.Payload
-
-module Current_file : sig
-  val set : filename_rel_to_project_root:string -> unit
-  val unset : unit -> unit
-end =
-  Current_file
-
-module Test_node = struct
-  type t = Test_node.t
-
-  module Create = Test_node.Create
-  module For_mlt = Test_node.For_mlt
-end
-
+module Expect_node_formatting = Expect_node_formatting
+module Compact_loc = Compact_loc
+module Expectation_id = Expectation_id
+module Delimiter = String_node_format.Delimiter
+module Payload = Payload
+module Current_file = Current_file
+module Test_node = Test_node
 module Write_corrected_file = Write_corrected_file
 module Make_test_block = Test_block.Make
 module For_external = Test_block.For_external
-module For_apply_style = Expectation.For_apply_style
+module For_apply_style = Test_spec.For_apply_style

--- a/runtime/ppx_expect_runtime.mli
+++ b/runtime/ppx_expect_runtime.mli
@@ -1,0 +1,111 @@
+[@@@alert
+  ppx_expect_runtime
+    "This module is intended for use in the implementation of ppx_expect only. Use \
+     [Expect_test_helpers_base] instead."]
+
+(** This library provides the runtime representation of expect tests and much of the logic
+    for running them.
+
+    The [Test_block] module defines the runtime representation of the whole
+    [let%expect_test] block. It exports a [Make] functor that is used in generated code to
+    produce a module from the locally bound [Expect_test_config]. [run_suite] from the
+    resulting module takes in remaining information about the expect test, including
+    inline test configurations, information about the contained expectations, and a
+    callback containing the body of the test.
+
+    The [~expectations] argument to [run_suite] is an assoc list mapping unique ids to
+    [Test_node.t]s. A [Test_node.t] stores the representation of a single [[%expect]] test
+    AST node and collects the results of tests that reach this node.
+
+    In the body of the test, the [[%expect]] AST nodes are replaced by calls to
+    [run_test], with the appropriate id passed as an argument.
+
+    For an example, consider a file that contains just the simple [let%expect_test] below:
+
+    {[
+      let%expect_test _ =
+        print_string "Hello";
+        [%expect {| Hello |}];
+        print_string "world";
+        [%expect_exact {x|world|x}]
+      ;;
+    ]}
+
+    It will expand to code that looks something like this:
+
+    {[
+      (* This statement is added to the top of each rewritten file; it is used to make
+         sure tests are only run from the files in which they are declared. *)
+      let () =
+        Ppx_expect_runtime.Current_file.set
+          ~filename_rel_to_project_root:"foo/bar/test/test.ml"
+
+      (* Each test expands into something that looks approximately like this. Some of the
+         arguments to [Ppx_expect_test_block.run_suite] are elided for clarity. *)
+      let () =
+        (* Prepare to read test output using the settings from [Expect_test_config] *)
+        let module Ppx_expect_test_block =
+          Ppx_expect_runtime.Make_test_block(Expect_test_config) in
+        Ppx_expect_test_block.run_suite
+          (* The name of the file in which the test is defined. This lets the runtime
+             check that the filename set here at ppx-time matches the one that is set by
+             the block above at runtime. If the test were defined in a functor and that
+             functor invoked from another file, the filenames would not match. *)
+          ~filename_rel_to_project_root:"foo/bar/test/test.ml"
+          (* The ids that should be used when registering the trailing output test and the
+             uncaught exception tests. They are minted at ppx time because that is the
+             time that it is easiest to guarantee their uniqueness. *)
+          ~trailing_test_id:(Ppx_expect_runtime.Expectation_id.of_int 2)
+          ~exn_test_id:(Ppx_expect_runtime.Expectation_id.of_int 3)
+          (* An assoc list mapping ids to representations of expect nodes that appear in
+             this test. Later, when encountering expect nodes, information about them is
+             looked up in this table. *)
+          ~expectations:(([(Ppx_expect_runtime.Expectation_id.of_int 1,
+                            Ppx_expect_runtime.Test_node.Create.expect_exact
+                              { contents = "world"; tag = (Tag "x") }
+                              { start_bol = ...; start_pos = ...; end_pos = ... });
+                           (Ppx_expect_runtime.Expectation_id.of_int 0,
+                            Ppx_expect_runtime.Test_node.Create.expect
+                              { contents = " Hello "; tag = (Tag "") }
+                              { start_bol = ...; start_pos = ...; end_pos = ... })])
+                        )
+          (* The body of the let binding is passed as a callback. *)
+          (fun () ->
+             print_string "Hello";
+             (* Tests are run by passing in the id of the encountered test node. *)
+             Ppx_expect_test_block.run_test
+               ~test_id:(Ppx_expect_runtime.Expectation_id.of_int 0);
+             print_string "world";
+             Ppx_expect_test_block.run_test
+               ~test_id:(Ppx_expect_runtime.Expectation_id.of_int 1))
+
+      (* This statement is added to the end of each file so that the expect test runtime
+         knows the file is finished executing and a new one can be set as current. *)
+      let () = Ppx_expect_runtime.Current_file.unset ()
+    ]}
+*)
+
+[@@@alert "-ppx_expect_runtime_types"]
+
+module Expect_node_formatting = Ppx_expect_runtime_types.Expect_node_formatting
+module Compact_loc = Ppx_expect_runtime_types.Compact_loc
+module Expectation_id = Ppx_expect_runtime_types.Expectation_id
+module Delimiter = Ppx_expect_runtime_types.String_node_format.Delimiter
+module Payload = Ppx_expect_runtime_types.Payload
+
+module Current_file : sig
+  val set : filename_rel_to_project_root:string -> unit
+  val unset : unit -> unit
+end
+
+module Test_node : sig
+  type t = Test_node.t
+
+  module Create = Test_node.Create
+  module For_mlt = Test_node.For_mlt
+end
+
+module Write_corrected_file = Write_corrected_file
+module Make_test_block = Test_block.Make
+module For_external = Test_block.For_external
+module For_apply_style = Test_spec.For_apply_style

--- a/runtime/runtime.wat
+++ b/runtime/runtime.wat
@@ -1,0 +1,42 @@
+(module
+   (import "env" "caml_ml_get_channel_fd"
+      (func $caml_ml_get_channel_fd (param (ref eq)) (result i32)))
+   (import "env" "caml_ml_set_channel_fd"
+      (func $caml_ml_set_channel_fd (param (ref eq)) (param i32)))
+   (import "env" "caml_ml_get_channel_offset"
+      (func $caml_ml_get_channel_offset (param (ref eq)) (result i64)))
+
+   (global $saved_stdout (mut i32) (i32.const 0))
+   (global $saved_stderr (mut i32) (i32.const 0))
+
+   (func (export "ppx_expect_runtime_before_test")
+      (param $output (ref eq)) (param $stdout (ref eq)) (param $stderr (ref eq))
+      (result (ref eq))
+      (local $fd i32)
+      (global.set $saved_stdout
+         (call $caml_ml_get_channel_fd (local.get $stdout)))
+      (global.set $saved_stderr
+         (call $caml_ml_get_channel_fd (local.get $stderr)))
+      (local.set $fd (call $caml_ml_get_channel_fd (local.get $output)))
+      (call $caml_ml_set_channel_fd (local.get $stdout) (local.get $fd))
+      (call $caml_ml_set_channel_fd (local.get $stderr) (local.get $fd))
+      (ref.i31 (i32.const 0)))
+
+   (func (export "ppx_expect_runtime_after_test")
+      (param $stdout (ref eq)) (param $stderr (ref eq)) (result (ref eq))
+      (call $caml_ml_set_channel_fd (local.get $stdout)
+         (global.get $saved_stdout))
+      (call $caml_ml_set_channel_fd (local.get $stderr)
+         (global.get $saved_stderr))
+      (ref.i31 (i32.const 0)))
+
+   (func (export "ppx_expect_runtime_out_channel_position")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31
+         (i32.wrap_i64
+            (call $caml_ml_get_channel_offset (local.get 0)))))
+
+   (func (export "ppx_expect_runtime_flush_stubs_streams")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 0)))
+)

--- a/runtime/test_block.ml
+++ b/runtime/test_block.ml
@@ -1,5 +1,5 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 (* [Shared] and [Configured] primarily contain boilerplate involving the FFI and printing
    [CR]s. The interesting logic is in [Make]. *)
@@ -205,22 +205,22 @@ end = struct
           ; location = _
           ; test_block = _
           }
-          ->
-      let sexp_here ~basename ~line_number : Sexp.t =
-        List
-          [ List [ Atom "file"; sexp_of_string basename ]
-          ; List [ Atom "line"; sexp_of_int line_number ]
-          ]
-      in
-      raise_s
-        (Sexp.message
-           "Expect_test_runtime: reached one [let%expect_test] from another. Nesting \
-            expect\n\
-            tests is prohibited."
-           [ ( "outer_test"
-             , sexp_here ~basename:outer_basename ~line_number:outer_line_number )
-           ; "inner_test", sexp_here ~basename ~line_number
-           ]))
+        ->
+        let sexp_here ~basename ~line_number : Sexp.t =
+          List
+            [ List [ Atom "file"; sexp_of_string basename ]
+            ; List [ Atom "line"; sexp_of_int line_number ]
+            ]
+        in
+        raise_s
+          (Sexp.message
+             "Expect_test_runtime: reached one [let%expect_test] from another. Nesting \
+              expect\n\
+              tests is prohibited."
+             [ ( "outer_test"
+               , sexp_here ~basename:outer_basename ~line_number:outer_line_number )
+             ; "inner_test", sexp_here ~basename ~line_number
+             ]))
   ;;
 end
 
@@ -293,7 +293,7 @@ module Make (C : Expect_test_config_types.S) = struct
         (* Create the tests for trailing output and uncaught exceptions *)
         let expectations =
           let trailing_test =
-            Expectation.expect_trailing
+            Test_spec.expect_trailing
               ~insert_loc:
                 { loc = { trailing_loc with end_pos = trailing_loc.start_pos }; body_loc }
             |> Test_node.of_expectation
@@ -301,13 +301,13 @@ module Make (C : Expect_test_config_types.S) = struct
           let exn_test =
             match expected_exn with
             | Some _ ->
-              Expectation.expect_uncaught_exn
+              Test_spec.expect_uncaught_exn
                 ~formatting_flexibility
                 ~located_payload:expected_exn
                 ~node_loc:trailing_loc
               |> Test_node.of_expectation
             | None ->
-              Expectation.expect_no_uncaught_exn
+              Test_spec.expect_no_uncaught_exn
                 ~insert_loc:{ loc = trailing_loc; body_loc }
               |> Test_node.of_expectation
           in
@@ -319,13 +319,13 @@ module Make (C : Expect_test_config_types.S) = struct
             ~absolute_filename
             expectations
             (fun ~original_file_contents ts ->
-            List.concat_map
-              ts
-              ~f:
-                (Test_node.For_mlt.to_diffs
-                   ~cr_for_multiple_outputs:Configured.cr_for_multiple_outputs
-                   ~expect_node_formatting:Expect_node_formatting.default
-                   ~original_file_contents))
+               List.concat_map
+                 ts
+                 ~f:
+                   (Test_node.For_mlt.to_diffs
+                      ~cr_for_multiple_outputs:Configured.cr_for_multiple_outputs
+                      ~expect_node_formatting:Expect_node_formatting.default
+                      ~original_file_contents))
         in
         (* To avoid capturing not-yet flushed data of the stdout/stderr buffers. *)
         Shared.flush ();
@@ -382,22 +382,22 @@ let at_exit () =
         ; location = { start_bol; start_pos; end_pos }
         ; test_block
         }
-        ->
-    Shared.flush ();
-    let fin = Stdlib.open_in (Shared.output_file test_block) in
-    let all_out = Stdlib.really_input_string fin (Stdlib.in_channel_length fin) in
-    Shared.clean_up_block test_block;
-    Stdlib.Printf.eprintf
-      "File %S, line %d, characters %d-%d:\n\
-       Error: program exited while expect test was running!\n\
-       Output captured so far:\n\
-       %s\n\
-       %!"
-      basename
-      line_number
-      (start_pos - start_bol)
-      (end_pos - start_bol)
-      all_out)
+      ->
+      Shared.flush ();
+      let fin = Stdlib.open_in (Shared.output_file test_block) in
+      let all_out = Stdlib.really_input_string fin (Stdlib.in_channel_length fin) in
+      Shared.clean_up_block test_block;
+      Stdlib.Printf.eprintf
+        "File %S, line %d, characters %d-%d:\n\
+         Error: program exited while expect test was running!\n\
+         Output captured so far:\n\
+         %s\n\
+         %!"
+        basename
+        line_number
+        (start_pos - start_bol)
+        (end_pos - start_bol)
+        all_out)
 ;;
 
 module For_external = struct
@@ -418,5 +418,16 @@ module For_external = struct
   let default_cr_for_multiple_outputs =
     let module Configured = Configured (Expect_test_config) in
     Configured.cr_for_multiple_outputs
+  ;;
+
+  let current_test_has_output_that_does_not_match_exn ~here =
+    match Current_test.current_test () with
+    | Some test_block -> !(Shared.failure_ref test_block)
+    | None ->
+      raise_s
+        (Sexp.message
+           "Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn \
+            called while there are no tests running"
+           [ "", Source_code_position.sexp_of_t here ])
   ;;
 end

--- a/runtime/test_block.ml
+++ b/runtime/test_block.ml
@@ -51,9 +51,9 @@ end = struct
       Current_file.absolute_path (Stdlib.Filename.temp_file "expect-test" "output")
     in
     let test_output_writer =
-      Stdlib.open_out_gen [ Open_wronly; Open_creat ] 0o644 output_file
+      Stdlib.open_out_gen [ Open_wronly; Open_creat; Open_binary ] 0o644 output_file
     in
-    let test_output_reader = Stdlib.open_in output_file in
+    let test_output_reader = Stdlib.open_in_bin output_file in
     redirect_stdout ~output:test_output_writer ~stdout:Stdlib.stdout ~stderr:Stdlib.stderr;
     { src_filename
     ; output_file
@@ -384,7 +384,7 @@ let at_exit () =
         }
       ->
       Shared.flush ();
-      let fin = Stdlib.open_in (Shared.output_file test_block) in
+      let fin = Stdlib.open_in_bin (Shared.output_file test_block) in
       let all_out = Stdlib.really_input_string fin (Stdlib.in_channel_length fin) in
       Shared.clean_up_block test_block;
       Stdlib.Printf.eprintf

--- a/runtime/test_block.mli
+++ b/runtime/test_block.mli
@@ -1,5 +1,5 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 (** Functor for building the runtime representation of a [let%expect_test] block *)
 
@@ -49,7 +49,7 @@ module Make (C : Expect_test_config_types.S) : sig
          (** Range of characters of the RHS of the [let%expect_test] binding. *)
     -> formatting_flexibility:Expect_node_formatting.Flexibility.t
          (** The formatting flexibility to use for the uncaught exn test. *)
-    -> expected_exn:(Output.Payload.t * Compact_loc.t) option
+    -> expected_exn:(Payload.t * Compact_loc.t) option
          (** Contents of the [[@@expect.uncaught_exn]] node, if any. *)
     -> trailing_test_id:Expectation_id.t
          (** ID to use for the test checking that there is no trailing output. *)
@@ -88,6 +88,17 @@ module For_external : sig
     :  output_name:string
     -> outputs:string list
     -> string
+
+  (** If the current test has reached a [[%expect]], [[%expect_exact]], or
+      [[%expect.if_reached]] node whose output does not match the expected output, or if
+      it has reached a [[%expect.unreachable]] node at all, returns [true].
+
+      If the current test does not meet those criteria, returns [false].
+
+      If there is no current test running, raises an error including [here]. *)
+  val current_test_has_output_that_does_not_match_exn
+    :  here:Source_code_position.t
+    -> bool
 end
 
 (** Action to perform when exiting from a program that runs expect tests. Alerts of

--- a/runtime/test_node.mli
+++ b/runtime/test_node.mli
@@ -1,5 +1,5 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 (** Accumulator of test results for one expect node *)
 type t
@@ -12,25 +12,23 @@ module Create : sig
       the e.g. [[%expect]] test.
   *)
 
-  (** [[%expect _]] *)
-  val expect
-    :  formatting_flexibility:Expect_node_formatting.Flexibility.t
-         (** If tests should be flexible about formatting rules, the formatting rules that
+  type expect_creator :=
+    formatting_flexibility:Expect_node_formatting.Flexibility.t
+      (** If tests should be flexible about formatting rules, the formatting rules that
         define this flexibility *)
-    -> node_loc:Compact_loc.t (** Location of the [[%expect _]] node *)
-    -> located_payload:(Output.Payload.t * Compact_loc.t) option
+    -> node_loc:Compact_loc.t (** Location of the [[%expect... _]] node *)
+    -> located_payload:(Payload.t * Compact_loc.t) option
          (** The string payload and its location, if there is one *)
     -> t
 
+  (** [[%expect _]] *)
+  val expect : expect_creator
+
   (** [[%expect_exact _]] *)
-  val expect_exact
-    :  formatting_flexibility:Expect_node_formatting.Flexibility.t
-         (** If tests should be flexible about formatting rules, the formatting rules that
-        define this flexibility *)
-    -> node_loc:Compact_loc.t (** Location of the [[%expect_exact _]] node *)
-    -> located_payload:(Output.Payload.t * Compact_loc.t) option
-         (** The string payload and its location, if there is one *)
-    -> t
+  val expect_exact : expect_creator
+
+  (** [[%expect.if_reached _]] *)
+  val expect_if_reached : expect_creator
 
   (** [[%expect.unreachable]] *)
   val expect_unreachable
@@ -40,7 +38,7 @@ end
 
 (** Functions exported for use in other modules of the expect test runtime. *)
 
-val of_expectation : [< Expectation.Behavior_type.t ] Expectation.t -> t
+val of_expectation : [< Test_spec.Behavior_type.t ] Test_spec.t -> t
 
 (** Updates reachedness information for [t]. *)
 val record_end_of_run : t -> unit

--- a/runtime/test_spec.mli
+++ b/runtime/test_spec.mli
@@ -1,0 +1,1 @@
+include Test_spec_intf.Test_spec

--- a/runtime/types/dune
+++ b/runtime/types/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_expect_runtime_types)
+ (public_name ppx_expect.runtime_types)
+ (libraries base)
+ (preprocess no_preprocessing))

--- a/runtime/write_corrected_file.ml
+++ b/runtime/write_corrected_file.ml
@@ -39,7 +39,7 @@ let f ~use_color ~in_place ~diff_command ~diff_path_prefix ~filename ~with_ corr
   =
   let dot_corrected = filename ^ ".corrected" in
   let original_file_contents =
-    let in_channel = Stdlib.open_in filename in
+    let in_channel = Stdlib.open_in_bin filename in
     let contents =
       Stdlib.really_input_string in_channel (Stdlib.in_channel_length in_channel)
     in

--- a/runtime/write_corrected_file.mli
+++ b/runtime/write_corrected_file.mli
@@ -1,5 +1,5 @@
 open! Base
-open Types
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 (** The callback expected by [f], which should convert the input to patches and is
     allowed to access the contents of the original file while doing so. *)

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
  (name ppx_expect)
  (public_name ppx_expect)
  (kind ppx_rewriter)
- (libraries base ppxlib ppx_expect_runtime ppx_inline_test
+ (libraries base ppxlib ppx_expect_runtime_types ppx_inline_test
    ppx_inline_test.libname ppx_here.expander)
  (ppx_runtime_libraries ppx_expect.runtime ppx_expect.config)
  (preprocess

--- a/src/ppx_expect.mli
+++ b/src/ppx_expect.mli
@@ -1,6 +1,6 @@
 open! Base
 open Ppxlib
-open Ppx_expect_runtime
+open Ppx_expect_runtime_types [@@alert "-ppx_expect_runtime_types"]
 
 val compact_loc_of_ppxlib_location : location -> Compact_loc.t
 

--- a/test/current_test_has_output_that_does_not_match_exn.ml
+++ b/test/current_test_has_output_that_does_not_match_exn.ml
@@ -1,0 +1,31 @@
+[@@@alert "-ppx_expect_runtime"]
+
+let%expect_test "not failing" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| false |}];
+  print_string "world";
+  [%expect {| world |}]
+;;
+
+let result =
+  try
+    Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+      ~here:[%here]
+    |> string_of_bool
+  with
+  | exn -> Printexc.to_string exn
+;;
+
+let%expect_test "raises outside of test" =
+  print_string result;
+  [%expect
+    {|
+    ("Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn called while there are no tests running"
+      ppx/ppx_expect/test/current_test_has_output_that_does_not_match_exn.ml:18:12)
+    |}]
+;;

--- a/test/current_test_has_output_that_does_not_match_exn.mli
+++ b/test/current_test_has_output_that_does_not_match_exn.mli
@@ -1,0 +1,1 @@
+(*_ This signature is deliberately empty. *)

--- a/test/dune
+++ b/test/dune
@@ -5,4 +5,4 @@
  (name ppx_expect_test)
  (flags :standard -principal)
  (preprocess
-  (pps ppx_assert ppx_expect)))
+  (pps ppx_assert ppx_expect ppx_here)))

--- a/test/duplicated-by-ppx/dune
+++ b/test/duplicated-by-ppx/dune
@@ -1,0 +1,4 @@
+(library
+ (name expect_test_copied_by_ppx_tests)
+ (preprocess
+  (pps ppx_expect ppx_duplicate_for_ppx_expect_internal_testing)))

--- a/test/duplicated-by-ppx/duplicated_expect.ml
+++ b/test/duplicated-by-ppx/duplicated_expect.ml
@@ -1,0 +1,5 @@
+[%%duplicate
+  let%expect_test "apples and apples" =
+    print_endline "buy apple";
+    [%expect {| buy apple |}]
+  ;;]

--- a/test/duplicated-by-ppx/negative-tests/dune
+++ b/test/duplicated-by-ppx/negative-tests/dune
@@ -1,0 +1,37 @@
+(library
+ (name expect_test_copied_by_ppx_negative_tests)
+ (preprocess
+  (pps ppx_expect ppx_duplicate_for_ppx_expect_internal_testing))
+ (libraries ppx_expect_runtime))
+
+(rule
+ (deps
+  (:first_dep ./inline_tests_runner)
+  ./inline_tests_runner.exe
+  %{workspace_root}/bin/apply-style
+  jbuild
+  (glob_files *.ml))
+ (targets duplicated_expect.ml.corrected duplicated_inconsistent.ml.corrected
+   test-output)
+ (action
+  (bash
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
+
+(rule
+ (alias runtest)
+ (deps duplicated_expect.ml.corrected.expected duplicated_expect.ml.corrected)
+ (action
+  (bash "diff -a %{deps}")))
+
+(rule
+ (alias runtest)
+ (deps duplicated_inconsistent.ml.corrected.expected
+   duplicated_inconsistent.ml.corrected)
+ (action
+  (bash "diff -a %{deps}")))
+
+(rule
+ (alias runtest)
+ (deps test-output.expected test-output)
+ (action
+  (bash "diff -a %{deps}")))

--- a/test/duplicated-by-ppx/negative-tests/duplicated_expect.ml
+++ b/test/duplicated-by-ppx/negative-tests/duplicated_expect.ml
@@ -1,0 +1,5 @@
+[%%duplicate
+  let%expect_test "apples and oranges" =
+    print_endline "buy apple";
+    [%expect {| buy orange |}]
+  ;;]

--- a/test/duplicated-by-ppx/negative-tests/duplicated_expect.ml.corrected.expected
+++ b/test/duplicated-by-ppx/negative-tests/duplicated_expect.ml.corrected.expected
@@ -1,0 +1,5 @@
+[%%duplicate
+  let%expect_test "apples and oranges" =
+    print_endline "buy apple";
+    [%expect {| buy apple |}]
+  ;;]

--- a/test/duplicated-by-ppx/negative-tests/duplicated_inconsistent.ml
+++ b/test/duplicated-by-ppx/negative-tests/duplicated_inconsistent.ml
@@ -1,0 +1,14 @@
+module Expect_test_config = struct
+  include Expect_test_config
+
+  let upon_unreleasable_issue = `Warning_for_collector_testing
+end
+
+let x = ref 0
+
+[%%duplicate
+  let%expect_test "what is x" =
+    x := !x + 1;
+    print_int !x;
+    [%expect {| |}]
+  ;;]

--- a/test/duplicated-by-ppx/negative-tests/duplicated_inconsistent.ml.corrected.expected
+++ b/test/duplicated-by-ppx/negative-tests/duplicated_inconsistent.ml.corrected.expected
@@ -1,0 +1,21 @@
+module Expect_test_config = struct
+  include Expect_test_config
+
+  let upon_unreleasable_issue = `Warning_for_collector_testing
+end
+
+let x = ref 0
+
+[%%duplicate
+  let%expect_test "what is x" =
+    x := !x + 1;
+    print_int !x;
+    [%expect
+      {|
+      (* expect_test: Test ran multiple times with different test outputs *)
+      ============================ Output 1 / 2 ============================
+      1
+      ============================ Output 2 / 2 ============================
+      2
+      |}]
+  ;;]

--- a/test/duplicated-by-ppx/negative-tests/test-output.expected
+++ b/test/duplicated-by-ppx/negative-tests/test-output.expected
@@ -1,0 +1,33 @@
+------ duplicated_expect.ml
+++++++ duplicated_expect.ml.corrected
+File "duplicated_expect.ml", line 4, characters 0-1:
+ |[%%duplicate
+ |  let%expect_test "apples and oranges" =
+ |    print_endline "buy apple";
+-|    [%expect {| buy orange |}]
++|    [%expect {| buy apple |}]
+ |  ;;]
+------ duplicated_inconsistent.ml
+++++++ duplicated_inconsistent.ml.corrected
+File "duplicated_inconsistent.ml", line 13, characters 0-1:
+ |module Expect_test_config = struct
+ |  include Expect_test_config
+ |
+ |  let upon_unreleasable_issue = `Warning_for_collector_testing
+ |end
+ |
+ |let x = ref 0
+ |
+ |[%%duplicate
+ |  let%expect_test "what is x" =
+ |    x := !x + 1;
+ |    print_int !x;
+-|    [%expect {| |}]
++|    [%expect {|
++|      (* expect_test: Test ran multiple times with different test outputs *)
++|      ============================ Output 1 / 2 ============================
++|      1
++|      ============================ Output 2 / 2 ============================
++|      2
++|      |}]
+ |  ;;]

--- a/test/duplicated-by-ppx/ppx-duplicate/dune
+++ b/test/duplicated-by-ppx/ppx-duplicate/dune
@@ -1,0 +1,6 @@
+(library
+ (name ppx_duplicate_for_ppx_expect_internal_testing)
+ (kind ppx_rewriter)
+ (libraries base ppxlib)
+ (preprocess
+  (pps ppx_jane ppxlib.metaquot)))

--- a/test/duplicated-by-ppx/ppx-duplicate/ppx_duplicate_for_ppx_expect_internal_testing.ml
+++ b/test/duplicated-by-ppx/ppx-duplicate/ppx_duplicate_for_ppx_expect_internal_testing.ml
@@ -1,0 +1,28 @@
+open! Base
+open Ppxlib
+
+let very_ghost =
+  object
+    inherit Ppxlib.Ast_traverse.map
+    method! location loc = { loc with loc_ghost = true }
+  end
+;;
+
+let () =
+  Ppxlib.Driver.register_transformation
+    ~extensions:
+      [ Extension.declare
+          "duplicate-for-ppx-expect-internal-testing.duplicate"
+          Extension.Context.structure_item
+          Ast_pattern.(pstr __)
+          (fun ~loc ~path:_ str ->
+            let mod_ = Ast_builder.Default.pmod_structure ~loc str in
+            [%stri
+              include struct
+                include [%m mod_]
+                include [%m mod_]
+              end]
+            |> very_ghost#structure_item)
+      ]
+    "duplicate-for-ppx-expect-internal-testing"
+;;

--- a/test/duplicated-by-ppx/ppx-duplicate/ppx_duplicate_for_ppx_expect_internal_testing.mli
+++ b/test/duplicated-by-ppx/ppx-duplicate/ppx_duplicate_for_ppx_expect_internal_testing.mli
@@ -1,0 +1,1 @@
+(*_ This signature is deliberately empty. *)

--- a/test/example/dune
+++ b/test/example/dune
@@ -1,6 +1,6 @@
 (library
  (name expect_test_examples)
- (libraries core async)
+ (libraries core async unix)
  (preprocess
   (pps ppx_jane)))
 

--- a/test/example/tests.ml
+++ b/test/example/tests.ml
@@ -8,7 +8,8 @@ let pr s = Printf.printf "%s\n" s
 let%expect_test "foo" =
   pr "line1";
   pr (Sexp.to_string (sexp_of_t [ 1; 2; 3 ]));
-  [%expect {|
+  [%expect
+    {|
     line1
     (1 2 3)
     |}]

--- a/test/expect-if-reached/dune
+++ b/test/expect-if-reached/dune
@@ -1,0 +1,6 @@
+(library
+ (name expect_test_if_unreachable_tests)
+ (libraries core)
+ (preprocess
+  (pps ppx_jane
+    -expect-test-allow-output-block-to-suppress-reachability-check=true)))

--- a/test/expect-if-reached/negative-test/dune
+++ b/test/expect-if-reached/negative-test/dune
@@ -1,0 +1,39 @@
+(library
+ (name expect_test_if_unreachable_negative_tests)
+ (libraries core)
+ (preprocess
+  (pps ppx_jane
+    -expect-test-allow-output-block-to-suppress-reachability-check=true)))
+
+(rule
+ (deps
+  (:first_dep ./inline_tests_runner)
+  ./inline_tests_runner.exe
+  %{workspace_root}/bin/apply-style
+  jbuild
+  (glob_files *.ml))
+ (targets expect_if_reacheds_are_corrected.ml.corrected
+   expects_still_must_be_reached.ml.corrected test-output)
+ (action
+  (bash
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
+
+(rule
+ (alias runtest)
+ (deps expect_if_reacheds_are_corrected.ml.corrected.expected
+   expect_if_reacheds_are_corrected.ml.corrected)
+ (action
+  (bash "diff -a %{deps}")))
+
+(rule
+ (alias runtest)
+ (deps expects_still_must_be_reached.ml.corrected.expected
+   expects_still_must_be_reached.ml.corrected)
+ (action
+  (bash "diff -a %{deps}")))
+
+(rule
+ (alias runtest)
+ (deps test-output.expected test-output)
+ (action
+  (bash "diff -a %{deps}")))

--- a/test/expect-if-reached/negative-test/expect_if_reacheds_are_corrected.ml
+++ b/test/expect-if-reached/negative-test/expect_if_reacheds_are_corrected.ml
@@ -1,0 +1,8 @@
+open! Core
+
+let%expect_test "reached and incorrect" =
+  print_endline "Hello world!";
+  if String.( <> ) "apples" "oranges"
+  then [%expect.if_reached {| XXXXXXXXXXXX |}]
+  else [%expect.unreachable]
+;;

--- a/test/expect-if-reached/negative-test/expect_if_reacheds_are_corrected.ml.corrected.expected
+++ b/test/expect-if-reached/negative-test/expect_if_reacheds_are_corrected.ml.corrected.expected
@@ -1,0 +1,8 @@
+open! Core
+
+let%expect_test "reached and incorrect" =
+  print_endline "Hello world!";
+  if String.( <> ) "apples" "oranges"
+  then [%expect.if_reached {| Hello world! |}]
+  else [%expect.unreachable]
+;;

--- a/test/expect-if-reached/negative-test/expects_still_must_be_reached.ml
+++ b/test/expect-if-reached/negative-test/expects_still_must_be_reached.ml
@@ -1,0 +1,8 @@
+open! Core
+
+let%expect_test "a normal expect is unreached" =
+  print_endline "Hello world!";
+  if String.( <> ) "apples" "oranges"
+  then [%expect.if_reached {| Hello world! |}]
+  else [%expect {| XXXXXXXXXXXX |}]
+;;

--- a/test/expect-if-reached/negative-test/expects_still_must_be_reached.ml.corrected.expected
+++ b/test/expect-if-reached/negative-test/expects_still_must_be_reached.ml.corrected.expected
@@ -1,0 +1,8 @@
+open! Core
+
+let%expect_test "a normal expect is unreached" =
+  print_endline "Hello world!";
+  if String.( <> ) "apples" "oranges"
+  then [%expect.if_reached {| Hello world! |}]
+  else [%expect.unreachable]
+;;

--- a/test/expect-if-reached/negative-test/test-output.expected
+++ b/test/expect-if-reached/negative-test/test-output.expected
@@ -1,0 +1,24 @@
+------ expect_if_reacheds_are_corrected.ml
+++++++ expect_if_reacheds_are_corrected.ml.corrected
+File "expect_if_reacheds_are_corrected.ml", line 6, characters 0-1:
+ |open! Core
+ |
+ |let%expect_test "reached and incorrect" =
+ |  print_endline "Hello world!";
+ |  if String.( <> ) "apples" "oranges"
+-|  then [%expect.if_reached {| XXXXXXXXXXXX |}]
++|  then [%expect.if_reached {| Hello world! |}]
+ |  else [%expect.unreachable]
+ |;;
+------ expects_still_must_be_reached.ml
+++++++ expects_still_must_be_reached.ml.corrected
+File "expects_still_must_be_reached.ml", line 7, characters 0-1:
+ |open! Core
+ |
+ |let%expect_test "a normal expect is unreached" =
+ |  print_endline "Hello world!";
+ |  if String.( <> ) "apples" "oranges"
+ |  then [%expect.if_reached {| Hello world! |}]
+-|  else [%expect {| XXXXXXXXXXXX |}]
++|  else [%expect.unreachable]
+ |;;

--- a/test/expect-if-reached/passing_tests.ml
+++ b/test/expect-if-reached/passing_tests.ml
@@ -1,0 +1,35 @@
+open! Core
+
+let%expect_test "unreached" =
+  print_endline "Hello world!";
+  if String.( = ) "apples" "oranges"
+  then [%expect.if_reached {| XXXXXXXXXXXX |}]
+  else [%expect {| Hello world! |}]
+;;
+
+let%expect_test "reached and correct" =
+  print_endline "Hello world!";
+  if String.( = ) "buffalo" "buffalo"
+  then [%expect.if_reached {| Hello world! |}]
+  else [%expect.unreachable]
+;;
+
+module F (Arg : sig
+    val x : int
+  end) =
+struct
+  let%expect_test "sometimes reached within one proc" =
+    print_endline "Hello world!";
+    if Arg.x = 0
+    then [%expect.if_reached {| Hello world! |}]
+    else [%expect {| Hello world! |}]
+  ;;
+end
+
+module _ = F (struct
+    let x = 0
+  end)
+
+module _ = F (struct
+    let x = 1
+  end)

--- a/test/explicit-strict-false/negative-test/dune
+++ b/test/explicit-strict-false/negative-test/dune
@@ -14,7 +14,7 @@
  (targets nine.ml.corrected test-output)
  (action
   (bash
-    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in *.ml.corrected\ndo\n  %{workspace_root}/bin/apply-style \\\n    -directory-config jbuild \\\n    -original-file $(basename $f .corrected) \\\n    - < $f > $f.tmp\n  mv $f.tmp $f\ndone\n")))
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
 
 (rule
  (alias runtest)

--- a/test/explicit-strict-false/negative-test/nine.ml
+++ b/test/explicit-strict-false/negative-test/nine.ml
@@ -30,7 +30,8 @@ let%expect_test _ =
 
     let () =
       print_string "\nhello";
-      [%expect {|
+      [%expect
+        {|
 
                                               goodbye|}]
     ;;
@@ -56,7 +57,8 @@ let%expect_test _ =
 
     let () =
       print_string "\n\nhello";
-      [%expect {|
+      [%expect
+        {|
 
 
                                               goodbye|}]

--- a/test/explicit-strict-false/nine.ml
+++ b/test/explicit-strict-false/nine.ml
@@ -30,7 +30,8 @@ let%expect_test _ =
 
     let () =
       print_string "\nhello";
-      [%expect {|
+      [%expect
+        {|
 
                                               hello|}]
     ;;
@@ -56,7 +57,8 @@ let%expect_test _ =
 
     let () =
       print_string "\n\nhello";
-      [%expect {|
+      [%expect
+        {|
 
 
                                               hello|}]

--- a/test/explicit-strict-true/negative-test/dune
+++ b/test/explicit-strict-true/negative-test/dune
@@ -14,7 +14,7 @@
  (targets nine.ml.corrected test-output)
  (action
   (bash
-    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in *.ml.corrected\ndo\n  %{workspace_root}/bin/apply-style \\\n    -directory-config jbuild \\\n    -original-file $(basename $f .corrected) \\\n    - < $f > $f.tmp\n  mv $f.tmp $f\ndone\n")))
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
 
 (rule
  (alias runtest)

--- a/test/explicit-strict-true/negative-test/nine.ml
+++ b/test/explicit-strict-true/negative-test/nine.ml
@@ -31,7 +31,8 @@ let%expect_test _ =
 
     let () =
       print_string "\nhello";
-      [%expect {|
+      [%expect
+        {|
 
                                               hello|}]
     ;;
@@ -57,7 +58,8 @@ let%expect_test _ =
 
     let () =
       print_string "\n\nhello";
-      [%expect {|
+      [%expect
+        {|
 
 
                                               hello|}]

--- a/test/force-drop/lib/dune
+++ b/test/force-drop/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name expect_test_force_drop_integration_lib)
- (libraries)
+ (libraries expect_test_config_types)
  (preprocess
   (pps ppx_expect)))

--- a/test/force-drop/lib/expect_test_force_drop_integration_lib.ml
+++ b/test/force-drop/lib/expect_test_force_drop_integration_lib.ml
@@ -1,6 +1,6 @@
 (* Shadow the runtime so that we can see if we enter the body of the test functor *)
 module Ppx_expect_runtime = struct
-  include Ppx_expect_runtime
+  include Ppx_expect_runtime [@@alert "-ppx_expect_runtime"]
 
   module Make_test_block (C : Expect_test_config_types.S) = struct
     let () = failwith "entered test functor"

--- a/test/negative-tests/cinaps/dune
+++ b/test/negative-tests/cinaps/dune
@@ -1,5 +1,5 @@
 (library
  (name expect_test_negative_tests_cinaps)
- (libraries core sexp_pretty stdio filesystem_core)
+ (libraries core sexp_pretty stdio file_path filesystem_core)
  (preprocess
   (pps ppx_jane ppx_string_dedent)))

--- a/test/negative-tests/comment.ml
+++ b/test/negative-tests/comment.ml
@@ -1,5 +1,5 @@
 let () = Printexc.record_backtrace false
 
 let%expect_test _ = raise (Failure "RIP")
-  (* this fails, but the comment stays *) [@@expect.uncaught_exn {||}]
+(* this fails, but the comment stays *) [@@expect.uncaught_exn {||}]
 ;;

--- a/test/negative-tests/current_test_has_output_that_does_not_match_exn.ml
+++ b/test/negative-tests/current_test_has_output_that_does_not_match_exn.ml
@@ -1,0 +1,37 @@
+[@@@alert "-ppx_expect_runtime"]
+
+let%expect_test "not failing" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| false |}];
+  print_string "world";
+  [%expect {| world |}]
+;;
+
+let%expect_test "failing" =
+  print_string "hello";
+  [%expect {| goodbye |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| |}];
+  print_string "world";
+  [%expect {| world |}]
+;;
+
+let%expect_test "not failing 2 --- 'failure state' is not preserved across tests" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| false |}];
+  print_string "world";
+  [%expect {| |}]
+;;

--- a/test/negative-tests/current_test_has_output_that_does_not_match_exn.ml.corrected.expected
+++ b/test/negative-tests/current_test_has_output_that_does_not_match_exn.ml.corrected.expected
@@ -1,0 +1,37 @@
+[@@@alert "-ppx_expect_runtime"]
+
+let%expect_test "not failing" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| false |}];
+  print_string "world";
+  [%expect {| world |}]
+;;
+
+let%expect_test "failing" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| true |}];
+  print_string "world";
+  [%expect {| world |}]
+;;
+
+let%expect_test "not failing 2 --- 'failure state' is not preserved across tests" =
+  print_string "hello";
+  [%expect {| hello |}];
+  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+    ~here:[%here]
+  |> string_of_bool
+  |> print_endline;
+  [%expect {| false |}];
+  print_string "world";
+  [%expect {| world |}]
+;;

--- a/test/negative-tests/dune
+++ b/test/negative-tests/dune
@@ -1,6 +1,6 @@
 (library
  (name expect_test_negative_tests)
- (libraries core)
+ (libraries core ppx_expect_runtime)
  (preprocess
   (pps ppx_jane)))
 
@@ -12,6 +12,7 @@
   jbuild
   (glob_files *.ml))
  (targets chdir.ml.corrected comment.ml.corrected
+   current_test_has_output_that_does_not_match_exn.ml.corrected
    escaped_strings.ml.corrected exact.ml.corrected exn.ml.corrected
    exn_and_trailing.ml.corrected exn_missing.ml.corrected
    expect_output.ml.corrected flexible.ml.corrected
@@ -25,7 +26,7 @@
    test-output)
  (action
   (bash
-    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in *.ml.corrected\ndo\n  %{workspace_root}/bin/apply-style \\\n    -directory-config jbuild \\\n    -original-file $(basename $f .corrected) \\\n    - < $f > $f.tmp\n  mv $f.tmp $f\ndone\n")))
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
 
 (rule
  (alias runtest)
@@ -36,6 +37,13 @@
 (rule
  (alias runtest)
  (deps comment.ml.corrected.expected comment.ml.corrected)
+ (action
+  (bash "diff -a %{deps}")))
+
+(rule
+ (alias runtest)
+ (deps current_test_has_output_that_does_not_match_exn.ml.corrected.expected
+   current_test_has_output_that_does_not_match_exn.ml.corrected)
  (action
   (bash "diff -a %{deps}")))
 

--- a/test/negative-tests/escaped_strings.ml
+++ b/test/negative-tests/escaped_strings.ml
@@ -55,10 +55,12 @@ let%expect_test "unescaped carriage return --- empty expect" =
 
 let%expect_test "unescaped carriage return --- populated expect" =
   print_string "a\r\nb";
-  [%expect {|
+  [%expect
+    {|
     a
     b |}];
   print_string "a\r\nb";
-  [%expect_exact {|a
+  [%expect_exact
+    {|a
 b|}]
 ;;

--- a/test/negative-tests/exact.ml
+++ b/test/negative-tests/exact.ml
@@ -3,7 +3,8 @@ open! Core
 (* Check that [%expect_exact] does not strip leading/trailing newlines *)
 let%expect_test _ =
   print_string "foobarbaz";
-  [%expect_exact {|
+  [%expect_exact
+    {|
   foobarbaz
   |}]
 ;;
@@ -11,7 +12,8 @@ let%expect_test _ =
 (* Check that [%expect_exact] does not treat whitespace as indentation *)
 let%expect_test _ =
   print_string "\nfoobarbaz\n";
-  [%expect_exact {|
+  [%expect_exact
+    {|
     foobarbaz
   |}]
 ;;

--- a/test/negative-tests/exn.ml
+++ b/test/negative-tests/exn.ml
@@ -11,7 +11,8 @@ let%expect_test _ =
   Printexc.record_backtrace false;
   ignore (failwith "hi ho" : unit);
   [%expect.unreachable]
-  [@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   (Failure "hi ho")
 |}]
 ;;

--- a/test/negative-tests/exn_and_trailing.ml
+++ b/test/negative-tests/exn_and_trailing.ml
@@ -2,5 +2,5 @@ let%expect_test _ =
   print_endline "hello";
   if true then raise Exit;
   [%expect {| hello |}]
-  [@@expect.uncaught_exn {| Exit |}]
+[@@expect.uncaught_exn {| Exit |}]
 ;;

--- a/test/negative-tests/exn_missing.ml
+++ b/test/negative-tests/exn_missing.ml
@@ -3,9 +3,9 @@ open! Core
 let%expect_test "without trailing output" =
   printf "hello world";
   [%expect "hello world"]
-  [@@expect.uncaught_exn {| (Failure "hi ho") |}]
+[@@expect.uncaught_exn {| (Failure "hi ho") |}]
 ;;
 
 let%expect_test "with trailing output" = printf "hello world"
-  [@@expect.uncaught_exn {| (Failure "hi ho") |}]
+[@@expect.uncaught_exn {| (Failure "hi ho") |}]
 ;;

--- a/test/negative-tests/flexible.ml
+++ b/test/negative-tests/flexible.ml
@@ -18,37 +18,43 @@ let%expect_test _ =
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|
+  [%expect
+    {|
   |}]
 ;;
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|
+  [%expect
+    {|
            |}]
 ;;
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|  WRONG
+  [%expect
+    {|  WRONG
            |}]
 ;;
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|  WRONG
+  [%expect
+    {|  WRONG
            |}]
 ;;
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|
+  [%expect
+    {|
   WRONG |}]
 ;;
 
 let%expect_test _ =
   print_string "hello";
-  [%expect {|
+  [%expect
+    {|
        WRONG
   |}]
 ;;
@@ -62,45 +68,52 @@ let%expect_test _ =
 
 let%expect_test _ =
   print_string "one2\ntwo";
-  [%expect {|
+  [%expect
+    {|
   |}]
 ;;
 
 let%expect_test _ =
   print_string "one3\ntwo";
-  [%expect {|
+  [%expect
+    {|
            |}]
 ;;
 
 let%expect_test _ =
   print_string "one4\ntwo";
-  [%expect {|  WRONG
+  [%expect
+    {|  WRONG
            |}]
 ;;
 
 let%expect_test _ =
   print_string "one5\ntwo";
-  [%expect {|
+  [%expect
+    {|
   WRONG |}]
 ;;
 
 let%expect_test _ =
   print_string "one6\ntwo";
-  [%expect {|
+  [%expect
+    {|
        WRONG
   |}]
 ;;
 
 let%expect_test _ =
   print_string "one8\ntwo";
-  [%expect {|
+  [%expect
+    {|
   WRONG
   THING |}]
 ;;
 
 let%expect_test _ =
   print_string "one9\ntwo";
-  [%expect {|
+  [%expect
+    {|
        WRONG
        THING
   |}]
@@ -108,7 +121,8 @@ let%expect_test _ =
 
 let%expect_test _ =
   print_string "one10\ntwo";
-  [%expect {|
+  [%expect
+    {|
        WRONG
           THING
   |}]
@@ -116,7 +130,8 @@ let%expect_test _ =
 
 let%expect_test _ =
   print_string "one11\ntwo";
-  [%expect {|
+  [%expect
+    {|
           WRONG
        THING
   |}]

--- a/test/negative-tests/for-mdx/dune
+++ b/test/negative-tests/for-mdx/dune
@@ -14,7 +14,7 @@
  (targets foo.ml.corrected mdx_cases.ml.corrected test-output)
  (action
   (bash
-    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color 2>&1 | tee >(sed '/part-end/q' > test-output) > /dev/null\nfor f in *.ml.corrected\ndo\n  %{workspace_root}/bin/apply-style \\\n    -directory-config jbuild \\\n    -original-file $(basename $f .corrected) \\\n    - < $f > $f.tmp\n  mv $f.tmp $f\ndone\n")))
+    "\nrm -f *.ml.corrected 2>/dev/null\n! %{first_dep} -no-color 2>&1 | tee >(sed '/part-end/q' > test-output) > /dev/null\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
 
 (rule
  (alias runtest)

--- a/test/negative-tests/for-mdx/mdx_cases.ml
+++ b/test/negative-tests/for-mdx/mdx_cases.ml
@@ -15,7 +15,8 @@ let%expect_test "interleaved" =
   printf "It has length %d\n" (List.length l);
   [%expect {| A list [l] |}];
   List.iter l ~f:print_string;
-  [%expect {|
+  [%expect
+    {|
     It has length 3
     abc
     |}]
@@ -91,7 +92,8 @@ Over many a quaint and curious
 (* $MDX part-begin=bad-format *)
 let%expect_test "bad formatting" =
   printf "a\n    b";
-  [%expect {|
+  [%expect
+    {|
 a
     b |}]
 ;;
@@ -155,8 +157,8 @@ let%expect_test "unreachable" =
 
 (* $MDX part-begin=sometimes-reachable *)
 module Test (B : sig
-  val interesting_opt : int option
-end) =
+    val interesting_opt : int option
+  end) =
 struct
   let%expect_test "sometimes reachable" =
     match B.interesting_opt with
@@ -168,23 +170,23 @@ struct
 end
 
 module _ = Test (struct
-  let interesting_opt = Some 5
-end)
+    let interesting_opt = Some 5
+  end)
 
 module _ = Test (struct
-  let interesting_opt = None
-end)
+    let interesting_opt = None
+  end)
 
 module _ = Test (struct
-  let interesting_opt = Some 5
-end)
+    let interesting_opt = Some 5
+  end)
 
 (* $MDX part-end *)
 
 (* $MDX part-begin=sometimes-raises *)
 module Test' (B : sig
-  val interesting_opt : int option
-end) =
+    val interesting_opt : int option
+  end) =
 struct
   let%expect_test "sometimes raises" =
     match B.interesting_opt with
@@ -196,16 +198,16 @@ struct
 end
 
 module _ = Test' (struct
-  let interesting_opt = Some 5
-end)
+    let interesting_opt = Some 5
+  end)
 
 module _ = Test' (struct
-  let interesting_opt = None
-end)
+    let interesting_opt = None
+  end)
 
 module _ = Test' (struct
-  let interesting_opt = Some 5
-end)
+    let interesting_opt = Some 5
+  end)
 
 (* $MDX part-end *)
 

--- a/test/negative-tests/functor.ml
+++ b/test/negative-tests/functor.ml
@@ -5,8 +5,8 @@ module Expect_test_config = struct
 end
 
 module M (S : sig
-  val output : string
-end) =
+    val output : string
+  end) =
 struct
   let%expect_test _ =
     print_string S.output;
@@ -23,18 +23,18 @@ struct
   let%expect_test _ =
     if String.equal S.output "bar" then print_string S.output else failwith "wrong output";
     [%expect.unreachable]
-    [@@expect.uncaught_exn {| (Failure "wrong output") |}]
+  [@@expect.uncaught_exn {| (Failure "wrong output") |}]
   ;;
 end
 
 module A = M (struct
-  let output = "foo"
-end)
+    let output = "foo"
+  end)
 
 module B = M (struct
-  let output = "bar"
-end)
+    let output = "bar"
+  end)
 
 module C = M (struct
-  let output = "cat"
-end)
+    let output = "cat"
+  end)

--- a/test/negative-tests/nesting/dune
+++ b/test/negative-tests/nesting/dune
@@ -14,7 +14,7 @@
  (targets nested.ml.corrected test-output)
  (action
   (bash
-    "\nrm -f *.ml.corrected 2>/dev/null\n! OCAMLRUNPARAM=b=0 %{first_dep} -require-tag fast-flambda -no-color > test-output 2>&1\nfor f in *.ml.corrected\ndo\n  %{workspace_root}/bin/apply-style \\\n    -directory-config jbuild \\\n    -original-file $(basename $f .corrected) \\\n    - < $f > $f.tmp\n  mv $f.tmp $f\ndone\n")))
+    "\nrm -f *.ml.corrected 2>/dev/null\n! OCAMLRUNPARAM=b=0 %{first_dep} -require-tag fast-flambda -no-color > test-output 2>&1\nfor f in %{targets}\ndo\n  if [[ $f == *.corrected ]]\n  then\n    if [[ -e $f ]]\n    then\n      %{workspace_root}/bin/apply-style \\\n        -directory-config jbuild \\\n        -original-file $(basename $f .corrected) \\\n        - < $f > $f.tmp\n      mv $f.tmp $f\n    else\n      echo \"=== Failed to generate corrected file ===\" > $f\n    fi\n  fi\ndone\n")))
 
 (rule
  (alias runtest)

--- a/test/negative-tests/nine.ml
+++ b/test/negative-tests/nine.ml
@@ -32,7 +32,8 @@ let%expect_test _ =
 
     let () =
       print_string "\nhello";
-      [%expect {|
+      [%expect
+        {|
 
                                               hello|}]
     ;;
@@ -58,7 +59,8 @@ let%expect_test _ =
 
     let () =
       print_string "\n\nhello";
-      [%expect {|
+      [%expect
+        {|
 
 
                                               hello|}]

--- a/test/negative-tests/normal_strings.ml
+++ b/test/negative-tests/normal_strings.ml
@@ -16,7 +16,8 @@ let%expect_test "long quoted string" =
 ;;
 
 let%expect_test "quoted strings with leading spaces" =
-  print_string {|
+  print_string
+    {|
     live
       long
         and

--- a/test/negative-tests/similar_distinct_outputs.ml
+++ b/test/negative-tests/similar_distinct_outputs.ml
@@ -1,6 +1,6 @@
 module M (S : sig
-  val foo : string
-end) =
+    val foo : string
+  end) =
 struct
   let%expect_test "similar passing" =
     print_string S.foo;
@@ -14,9 +14,9 @@ struct
 end
 
 module M1 = M (struct
-  let foo = "foo"
-end)
+    let foo = "foo"
+  end)
 
 module M2 = M (struct
-  let foo = "\n\nfoo\n\n"
-end)
+    let foo = "\n\nfoo\n\n"
+  end)

--- a/test/negative-tests/spacing.ml
+++ b/test/negative-tests/spacing.ml
@@ -3,7 +3,8 @@ open Core
 let%expect_test _ =
   let text_no_final_nl () = print_string "one\ntwo(no newline)\nthree" in
   text_no_final_nl ();
-  [%expect {|
+  [%expect
+    {|
 
   one
   two(no newline)
@@ -14,19 +15,22 @@ let%expect_test _ =
      .expected.patdiff *)
   let text n = Printf.printf "one\ntwo(%d)\nthree\n" n in
   text 1;
-  [%expect {|
+  [%expect
+    {|
   one
   two(1)
   three|}];
   text 2;
-  [%expect {|
+  [%expect
+    {|
     one
   two(2)
     three
   |}];
   (* Check that it reindents expectation properly *)
   printf "  one\n blah\n  three";
-  [%expect {|
+  [%expect
+    {|
       one
     two
       three

--- a/test/negative-tests/tag.ml
+++ b/test/negative-tests/tag.ml
@@ -14,7 +14,8 @@ let%expect_test _ =
   [%expect {||}];
   print_string "hey\\ho";
   [%expect_exact ""];
-  print_string {|
+  print_string
+    {|
     Foo
     "bar baz"|};
   [%expect.unreachable]

--- a/test/negative-tests/test-output.expected
+++ b/test/negative-tests/test-output.expected
@@ -5,7 +5,7 @@ File "export_test.ml", line 2, characters 2-24 threw
   \n- trying to run it from ppx/ppx_expect/test/negative-tests/import_test.ml\
   \n").
 
-FAILED 1 / 71 tests
+FAILED 1 / 74 tests
 ------ chdir.ml
 ++++++ chdir.ml.corrected
 File "chdir.ml", line 6, characters 0-1:
@@ -25,6 +25,49 @@ File "comment.ml", line 4, characters 0-1:
  |let%expect_test _ = raise (Failure "RIP")
 -|(* this fails, but the comment stays *) [@@expect.uncaught_exn {||}]
 +|(* this fails, but the comment stays *) [@@expect.uncaught_exn {| (Failure RIP) |}]
+ |;;
+------ current_test_has_output_that_does_not_match_exn.ml
+++++++ current_test_has_output_that_does_not_match_exn.ml.corrected
+File "current_test_has_output_that_does_not_match_exn.ml", line 17, characters 0-1:
+ |[@@@alert "-ppx_expect_runtime"]
+ |
+ |let%expect_test "not failing" =
+ |  print_string "hello";
+ |  [%expect {| hello |}];
+ |  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+ |    ~here:[%here]
+ |  |> string_of_bool
+ |  |> print_endline;
+ |  [%expect {| false |}];
+ |  print_string "world";
+ |  [%expect {| world |}]
+ |;;
+ |
+ |let%expect_test "failing" =
+ |  print_string "hello";
+-|  [%expect {| goodbye |}];
++|  [%expect {| hello |}];
+ |  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+ |    ~here:[%here]
+ |  |> string_of_bool
+ |  |> print_endline;
+-|  [%expect {| |}];
++|  [%expect {| true |}];
+ |  print_string "world";
+ |  [%expect {| world |}]
+ |;;
+ |
+ |let%expect_test "not failing 2 --- 'failure state' is not preserved across tests" =
+ |  print_string "hello";
+ |  [%expect {| hello |}];
+ |  Ppx_expect_runtime.For_external.current_test_has_output_that_does_not_match_exn
+ |    ~here:[%here]
+ |  |> string_of_bool
+ |  |> print_endline;
+ |  [%expect {| false |}];
+ |  print_string "world";
+-|  [%expect {| |}]
++|  [%expect {| world |}]
  |;;
 ------ escaped_strings.ml
 ++++++ escaped_strings.ml.corrected

--- a/test/negative-tests/three.ml
+++ b/test/negative-tests/three.ml
@@ -9,28 +9,32 @@
 let%expect_test _ =
   let text_no_final_nl () = print_string "one\ntwo\nthree" in
   text_no_final_nl ();
-  [%expect {|
+  [%expect
+    {|
   one
   two
   three|}];
   let text () = print_string "one\ntwo\nthree\n" in
   (* Base example *)
   text ();
-  [%expect {|
+  [%expect
+    {|
   one
   two
   three
 |}];
   (* ok to omit space between "expect" and "{" *)
   text ();
-  [%expect {|
+  [%expect
+    {|
   one
   two
   three
 |}];
   (* indentation allowed *)
   text ();
-  [%expect {|
+  [%expect
+    {|
   one
   two
   three

--- a/test/negative-tests/trailing_in_module.ml
+++ b/test/negative-tests/trailing_in_module.ml
@@ -2,8 +2,8 @@ open! Core
 
 module M (X : Sexpable) = struct
   module N (Y : sig
-    val x : X.t
-  end) =
+      val x : X.t
+    end) =
   struct
     let%expect_test "trailing output" =
       let sexp = X.sexp_of_t Y.x in
@@ -20,5 +20,5 @@ end
 module String_tests = M (String)
 
 module Run_on_abc = String_tests.N (struct
-  let x = "a\nb\nc"
-end)
+    let x = "a\nb\nc"
+  end)

--- a/test/test_output.ml
+++ b/test/test_output.ml
@@ -2,7 +2,8 @@ let%expect_test "expect.output" =
   Printf.printf "hello\n";
   let output = [%expect.output] in
   Printf.printf "'%s'\n" (String.uppercase_ascii output);
-  [%expect {|
+  [%expect
+    {|
     'HELLO
     '
     |}];

--- a/test/uncaught_exn.ml
+++ b/test/uncaught_exn.ml
@@ -1,12 +1,12 @@
 let%expect_test _ =
   Printexc.record_backtrace false;
   assert false
-  [@@expect.uncaught_exn {| "Assert_failure uncaught_exn.ml:3:2" |}]
+[@@expect.uncaught_exn {| "Assert_failure uncaught_exn.ml:3:2" |}]
 ;;
 
 let%expect_test "Expectation with uncaught expectation" =
   Printexc.record_backtrace false;
   ignore (assert false);
   [%expect.unreachable]
-  [@@expect.uncaught_exn {| "Assert_failure uncaught_exn.ml:9:10" |}]
+[@@expect.uncaught_exn {| "Assert_failure uncaught_exn.ml:9:10" |}]
 ;;


### PR DESCRIPTION
This was already fixed in v0.14. See https://github.com/janestreet/ppx_expect/pull/35