### PR TITLE
make v0.16 usable with js_of_ocaml GPR 1601

### DIFF
--- a/collector/runtime.js
+++ b/collector/runtime.js
@@ -4,29 +4,26 @@ var expect_test_collector_saved_stdout
 var expect_test_collector_saved_stderr
 
 //Provides: expect_test_collector_before_test
-//Requires: caml_global_data, caml_ml_channels
+//Requires: caml_global_data, caml_ml_channel_redirect
 //Requires: expect_test_collector_saved_stderr, expect_test_collector_saved_stdout
 function expect_test_collector_before_test (voutput, vstdout, vstderr){
-  expect_test_collector_saved_stderr = caml_ml_channels[vstderr];
-  expect_test_collector_saved_stdout = caml_ml_channels[vstdout];
-  var output = caml_ml_channels[voutput];
-  caml_ml_channels[vstdout] = output;
-  caml_ml_channels[vstderr] = output;
+  expect_test_collector_saved_stderr = caml_ml_channel_redirect(vstderr,voutput);
+  expect_test_collector_saved_stdout = caml_ml_channel_redirect(vstdout,voutput);
   return 0;
 }
 
 //Provides: expect_test_collector_after_test
-//Requires: caml_global_data, caml_ml_channels
+//Requires: caml_global_data, caml_ml_channel_restore
 //Requires: expect_test_collector_saved_stderr, expect_test_collector_saved_stdout
 function expect_test_collector_after_test (vstdout, vstderr){
-  caml_ml_channels[vstdout] = expect_test_collector_saved_stdout;
-  caml_ml_channels[vstderr] = expect_test_collector_saved_stderr;
+  caml_ml_channel_restore(vstdout,expect_test_collector_saved_stdout);
+  caml_ml_channel_restore(vstderr,expect_test_collector_saved_stderr);
   return 0;
 }
 
 //Provides:caml_out_channel_pos_fd
-//Requires: caml_global_data, caml_ml_channels
-function caml_out_channel_pos_fd(chan){
-  var info = caml_ml_channels[chan];
-  return info.offset
+//Requires: caml_global_data, caml_ml_channel_get
+function caml_out_channel_pos_fd(chanid){
+  var chan = caml_ml_channel_get(chanid);
+  return chan.offset
 }

--- a/ppx_expect.opam
+++ b/ppx_expect.opam
@@ -20,6 +20,9 @@ depends: [
   "ppxlib"          {>= "0.28.0"}
   "re"              {>= "1.8.0"}
 ]
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Cram like framework for OCaml"
 description: "


### PR DESCRIPTION
I'm requesting a minor release of ppx_expect.v0.16 that include #54. This would allow to merge https://github.com/ocsigen/js_of_ocaml/pull/1601 and fully fix the memory leak of ocaml channels reported in https://github.com/ocsigen/js_of_ocaml/pull/1577

The reason we need this for ppx_expect.v0.16 is that jsoo runs its expect tests with OCaml.4.14 and ppx_expect.v0.17 is not compatible with such versions.

@TyOverby, can you monitor this PR so that it doesn't get lost.  