### PR TITLE
bugfix: change file-naming scheme to account for multi-dir-deep dune libraries

### DIFF
--- a/runtime/current_file.ml
+++ b/runtime/current_file.ml
@@ -32,6 +32,11 @@ let initial_dir =
   lazy (Or_error.ok_exn dir_or_error)
 ;;
 
+let remove_top_dir file =
+  let maybe_split = String.lsplit2 ~on:'/' file in
+  Option.value_map ~f:(fun (_, suffix) -> suffix) ~default:file maybe_split
+;;
+
 let absolute_path file =
   if Stdlib.Filename.is_relative file
   then Stdlib.Filename.concat (Lazy.force initial_dir) file

--- a/runtime/current_file.mli
+++ b/runtime/current_file.mli
@@ -12,6 +12,12 @@ val get : unit -> string
     Forcing the [Lazy.t] raises if the initial call to [Stdlib.Sys.getcwd] raised. *)
 val initial_dir : string Lazy.t
 
+(** Given a path, removes the first element of that path.
+
+    i.e. if given foo/bar/file, returns bar/file
+   *)
+val remove_top_dir: string -> string
+
 (** Given a path relative to the initial working directory, returns an absolute path.
 
     Raises if the initial call to [Stdlib.Sys.getcwd] raised. *)

--- a/runtime/test_block.ml
+++ b/runtime/test_block.ml
@@ -524,7 +524,7 @@ module Make (C : Expect_test_config_types.S) = struct
     f
     =
     let ({ start_bol; start_pos; end_pos } : Compact_loc.t) = location in
-    let basename = Stdlib.Filename.basename filename_rel_to_project_root in
+    let basename = Current_file.remove_top_dir filename_rel_to_project_root in
     (* Even if the current tag set indicates this test should be dropped, check that it
        wasn't reached from another expect test *)
     Current_test.assert_no_test_running ~basename ~line_number;


### PR DESCRIPTION
This also allows you to use the library for `(include_subdirs qualified)`, which is perhaps the important contribution here :).
This closes #61.

I am very new to ocaml but got bitten by this in my learning project, so decided to fix it.
I tried to follow the style of the repo, if there are any style or implementation problems I'll fix them.
