### PR TITLE
Preserve nested expect-test correction paths

### DIFF
--- a/runtime/ppx_expect_runtime.ml
+++ b/runtime/ppx_expect_runtime.ml
@@ -12,7 +12,12 @@ let () =
           match Ppx_inline_test_lib.source_tree_root () with
           | None -> filename
           | Some source_tree_root ->
-            Stdlib.Filename.concat source_tree_root (Stdlib.Filename.basename filename)
+            let source_tree_filename =
+              Stdlib.Filename.concat source_tree_root (Stdlib.Filename.basename filename)
+            in
+            if Stdlib.Sys.file_exists source_tree_filename
+            then source_tree_filename
+            else filename
         in
         Write_corrected_file.f
           test_nodes

--- a/test/source-tree-root/test-verbose-mode.t
+++ b/test/source-tree-root/test-verbose-mode.t
@@ -33,3 +33,23 @@ Test absolute path
   $ cd $TEST_DIR
   $ ls *.corrected
   expect_test_source_tree_test.ml.corrected
+
+Test a source file next to the runner when it is nested beneath the source-tree
+root.
+
+  $ rm *.corrected
+  $ mv expect_test_source_tree_test.ml expect_test_source_tree_test.ml.saved
+  $ cp expect_test_source_tree_test.ml.saved $dir
+  $ cd $dir
+  $ ./inline_tests_runner -source-tree-root ../../.. -no-color 2>&1 | tail -n +4
+   |let%expect_test _ =
+   |  print_endline "hello world";
+  -|  [%expect {| |}]
+  +|  [%expect {| hello world |}]
+   |;;
+
+  $ ls *.corrected
+  expect_test_source_tree_test.ml.corrected
+  $ rm expect_test_source_tree_test.ml expect_test_source_tree_test.ml.corrected
+  $ cd $TEST_DIR
+  $ mv expect_test_source_tree_test.ml.saved expect_test_source_tree_test.ml


### PR DESCRIPTION
## Summary
- use the `-source-tree-root` correction path only when that candidate exists
- retain the already-correct absolute filename for nested inline-test runners
- extend the source-tree-root Cram coverage with a nested adjacent-source case

## Why
Dune invokes an inline-test runner in a subdirectory with the workspace root as `-source-tree-root`. Re-rooting the source filename by basename alone turns `test/t.ml` into `../t.ml`, so correction processing raises `Sys_error` even when the test output matches. The fallback preserves copied-runner support while avoiding that lossy rewrite when the source-tree candidate is absent.

## Validation
- `git diff --check`
- exercised both path-selection branches with a lightweight filesystem simulation
- added Cram regression coverage for the nested source path

Fixes #65